### PR TITLE
Upper bound the test dependency on StatsBase to 0.13.0

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,2 @@
-StatsBase
+StatsBase 0.0.0 0.13.0
 DataStructures


### PR DESCRIPTION
StatsBase v0.13.0 introduced a dependency on DataStructures. One of the tests in this package assumes that DataStructures is installed but is *not* defined (i.e. not explicitly imported). The testing code imports StatsBase, which defines DataStructures in Main on sufficiently recent versions. So the fix is actually pretty easy!

Fixes #1